### PR TITLE
Update podzilla-utils-lib version and change event type to INVENTORY_UPDATED

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>com.github.Podzilla</groupId>
             <artifactId>podzilla-utils-lib</artifactId>
-            <version>v1.1.12</version>
+            <version>v1.1.13</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/podzilla/warehouse/Services/StockService.java
+++ b/src/main/java/com/podzilla/warehouse/Services/StockService.java
@@ -94,7 +94,7 @@ public class StockService {
                             updated.getThreshold()
                     );
 
-                    eventPublisher.publishEvent(EventsConstants.PRODUCT_CREATED, event);
+                    eventPublisher.publishEvent(EventsConstants.INVENTORY_UPDATED, event);
 
                     return updated;
                 });


### PR DESCRIPTION
This pull request includes two changes: an update to a dependency version in `pom.xml` and a modification to an event type in the `StockService` class.

### Dependency Update:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L134-R134): Updated the `podzilla-utils-lib` dependency version from `v1.1.12` to `v1.1.13`.

### Event Type Modification:
* [`src/main/java/com/podzilla/warehouse/Services/StockService.java`](diffhunk://#diff-0ef5bf695348b11304109115e834ba5901a732e30a9a9738bd86bc6f59667400L97-R97): Changed the published event type from `PRODUCT_CREATED` to `INVENTORY_UPDATED` in the `updateStock` method.