### PR TITLE
Refactor relationships in AssignedOrders and Stock models

### DIFF
--- a/src/main/java/com/podzilla/warehouse/Models/AssignedOrders.java
+++ b/src/main/java/com/podzilla/warehouse/Models/AssignedOrders.java
@@ -33,7 +33,7 @@ public class AssignedOrders {
     private LocalDateTime assignedAt;
 
     @Column(nullable = false)
-    @OneToMany(mappedBy = "packagedOrder")
+    @OneToMany(mappedBy = "assignedOrder")
     private List<Stock> items;
 
     @Column(nullable = false)

--- a/src/main/java/com/podzilla/warehouse/Models/Stock.java
+++ b/src/main/java/com/podzilla/warehouse/Models/Stock.java
@@ -34,8 +34,14 @@ public class Stock {
 
     @Column(nullable = false)
     private String category;
+
+    // Add a new ManyToOne relationship back to AssignedOrders
     @ManyToOne
-    @JoinColumn(name = "order_id", nullable = true)
+    @JoinColumn(name = "assigned_order_id", nullable = true) // Use a different join column name
+    private AssignedOrders assignedOrder; // Use a different field name
+
+    @ManyToOne
+    @JoinColumn(name = "packaged_order_id", nullable = true)
     private PackagedOrders packagedOrder;
     @CreationTimestamp
     @Column(updatable = false)


### PR DESCRIPTION
This pull request updates the entity relationships in the `AssignedOrders` and `Stock` models to improve database consistency and better reflect the intended data structure. The changes include renaming a mapped field, introducing a new relationship, and modifying an existing join column.

### Changes to entity relationships:

* **`AssignedOrders` model**:
  - Updated the mapping of the `items` field to use `assignedOrder` instead of `packagedOrder` in the `Stock` entity. (`[src/main/java/com/podzilla/warehouse/Models/AssignedOrders.javaL36-R36](diffhunk://#diff-0903df3387465c62f90f237168b13fcec88a43dea606a450e13b29c9649bbd51L36-R36)`)

* **`Stock` model**:
  - Added a new `@ManyToOne` relationship to the `AssignedOrders` entity, with a join column named `assigned_order_id` and a nullable constraint. This introduces a reverse mapping to `AssignedOrders`. (`[src/main/java/com/podzilla/warehouse/Models/Stock.javaR37-R44](diffhunk://#diff-2e58d935c5017aa420bf97eefc92901538aa4fa2e972844fe5f1c118ad7686b1R37-R44)`)
  - Renamed the join column for the existing `packagedOrder` relationship to `packaged_order_id` for clarity and consistency. (`[src/main/java/com/podzilla/warehouse/Models/Stock.javaR37-R44](diffhunk://#diff-2e58d935c5017aa420bf97eefc92901538aa4fa2e972844fe5f1c118ad7686b1R37-R44)`)